### PR TITLE
Add recovery window to restores on has_one relationship records

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -188,7 +188,10 @@ module Paranoia
 
         association_class = association_class_name.constantize
         if association_class.paranoid?
-          association_class.only_deleted.where(association_find_conditions).first.try!(:restore, recursive: true)
+          association_class.only_deleted.
+            where("#{association.quoted_table_name}.#{paranoia_column} < ?", deleted_at + window).
+            where("#{association.quoted_table_name}.#{paranoia_column} > ?", deleted_at - window).
+            where(association_find_conditions).first.try!(:restore, recursive: true)
         end
       end
     end


### PR DESCRIPTION
Previously the recovery_window option only works when restoring collection
associations. This becomes problematic with has_one relationships because the
restore can cause a case where we have multiple associated records for the
has_one relationship.
